### PR TITLE
eredisのバージョン指定が不正だったので修正。

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -16,7 +16,7 @@
 
 {deps, [
         {eredis, 
-         "*",
+         ".*",
          {git, "git://github.com/groovenauts-erlang/eredis.git", 
           {branch, "master"}}},
 


### PR DESCRIPTION
以下のエラーが発生していた。

原因としてはバージョン指定が`*`となっており、正規表現の形式として正しくなかったため。

```
ERROR: 'get-deps' failed while processing /www/erlang/magellan-transaction-router/deps/eredis_pool
: {'EXIT',{badarg,[{re,run,["1.0.6","*",[{capture,none}]],[]},
                 {rebar_deps,is_app_available,5,
                             [{file,"src/rebar_deps.erl"},{line,441}]},
                 {rebar_deps,use_source,3,
                             [{file,"src/rebar_deps.erl"},{line,489}]},
                 {rebar_deps,'-get-deps/2-fun-0-',2,
                             [{file,"src/rebar_deps.erl"},{line,184}]},
                 {lists,foldl,3,[{file,"lists.erl"},{line,1261}]},
                 {rebar_deps,'get-deps',2,
                             [{file,"src/rebar_deps.erl"},{line,183}]},
                 {rebar_core,run_modules,4,
                             [{file,"src/rebar_core.erl"},{line,490}]},
                 {rebar_core,execute,6,
                             [{file,"src/rebar_core.erl"},{line,415}]}]}}
```
